### PR TITLE
Fix HQ confirmation prompt

### DIFF
--- a/SND Scripts/Stable Scripts/Leve Turnin - Lua Edition.lua
+++ b/SND Scripts/Stable Scripts/Leve Turnin - Lua Edition.lua
@@ -158,6 +158,12 @@
     yield("/wait 0.1")
     yield("/interact")
 
+    while IsAddonReady("SelectYesno") == false do
+      yield("/wait 0.1")
+    end
+
+    yield("/click select_yes")
+
     while GetTargetName() ~= "" do 
       yield("/wait 0.1")
     end 
@@ -168,4 +174,4 @@
         goto LUATEATURNIN
     else
         yield("/e Thank you for using the automated Leve Turnin")
-    end 
+    end


### PR DESCRIPTION
Added a bit to make the script properly handle the "Do you really want to hand in an HQ item" prompt. The previous version consistently hangs on this prompt.

There is a small chance for the /click to fail which I have yet to find an explanation for.